### PR TITLE
Added sanity check for failed user creation.

### DIFF
--- a/sb_welcome_email_editor.php
+++ b/sb_welcome_email_editor.php
@@ -278,7 +278,7 @@ if (!function_exists('wp_new_user_notification')) {
 			sb_we_set_email_filter_headers();
 		}
 
-		if ($user = new WP_User($user_id)) {
+		if ($user = new WP_User($user_id) && !is_wp_error($user_id)) {
 			$settings = get_option('sb_we_settings');
 
 			update_user_meta($user_id, 'sb_we_last_sent', time());


### PR DESCRIPTION
When registering new users and the username already exists wp will die with 
`PHP Catchable fatal error:  Object of class WP_Error could not be converted to string in /wp-content/plugins/welcome-email-editor/sb_welcome_email_editor.php on line 360`

This sanity check remedies that.
