### PR TITLE
Fix missing user notification

### DIFF
--- a/sb_welcome_email_editor.php
+++ b/sb_welcome_email_editor.php
@@ -420,7 +420,7 @@ if (!function_exists('wp_new_user_notification')) {
 				}
 			}
 
-			if ($notify && $notify != 'admin') { //needs to be like this for backwards compatibility
+			if ( empty( $notify ) || $notify != 'admin') { //needs to be like this for backwards compatibility
 				
 				//$login_url = $reset_pass_url = $sb_we_home . 'wp-login.php';
 				$login_url = $reset_pass_url = wp_login_url();


### PR DESCRIPTION
When no argument is supplied to the third parameter of `wp_new_user_notification()`, no notification is sent.  This differs from the overridden function of the same name in `wp-includes/pluggable.php`.   This update syncs the logic of the two with respect to user notification. This is my first pull request on GitHub so apologies if I did something wrong.
